### PR TITLE
Added scope for jest snippets for jsx and tsx files

### DIFF
--- a/snippets/javascript/jest/jest.json
+++ b/snippets/javascript/jest/jest.json
@@ -3,31 +3,31 @@
     "body": ["afterAll(() => {\n\t$0\n});"],
     "description": "afterAll function is called once after all specs",
     "prefix": ["jest afterall", "aa"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-aftereach": {
     "body": ["afterEach(() => {\n\t$0\n});"],
     "description": "afterEach function is called once after each spec",
     "prefix": ["jest aftereach", "ae"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-beforeall": {
     "body": ["beforeAll(() => {\n\t$0\n});"],
     "description": "beforeAll function is called once before all specs",
     "prefix": ["jest beforeall", "ba"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-beforeeach": {
     "body": ["beforeEach(() => {\n\t$0\n});"],
     "description": "beforeEach function is called once before each spec",
     "prefix": ["jest beforeeach", "be"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-describe": {
     "body": ["describe('${1:Name of the group}', () => {\n\t$0\n});"],
     "description": "creates a describe block",
     "prefix": ["jest describe", "desc"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-describe-each": {
     "body": [
@@ -42,55 +42,55 @@
     ],
     "description": "creates a describe block with different test data sets",
     "prefix": ["jest describe each", "desce"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-describe-only": {
     "body": ["describe.only('${1:Name of the group}', () => {\n\t$0\n});"],
     "description": "creates a describe block that runs only",
     "prefix": ["jest describe only", "desco"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-describe-skip": {
     "body": ["describe.skip('${1:Name of the group}', () => {\n\t$0\n});"],
     "description": "creates a describe block that will be skipped",
     "prefix": ["jest describe skip", "descs"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-expect": {
     "body": ["expect($0)"],
     "description": "expect actual value",
     "prefix": ["jest expect", "exp"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-expect-assertions": {
     "body": ["expect.assertions($0);"],
     "description": "expects the test to make the indicated number of assertions (useful for async)",
     "prefix": ["jest expect assertions", "expas"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-expect-hasassertions": {
     "body": ["expect.hasAssertions();$0"],
     "description": "expects the test to make at least one assertion (useful for async)",
     "prefix": ["jest expect hasassertions", "expha"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-expect-rejects": {
     "body": ["expect($1).rejects$0"],
     "description": "expect promise rejects to",
     "prefix": ["jest expect rejects", "exprj"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-expect-resolves": {
     "body": ["expect($1).resolves$0"],
     "description": "expect promise resolves to",
     "prefix": ["jest expect resolves", "expr"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-it": {
     "body": ["it('${1:should }', () => {\n\t$0\n});"],
     "description": "creates an it block",
     "prefix": ["jest it", "it"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-it-each": {
     "body": [
@@ -103,37 +103,37 @@
     ],
     "description": "creates an it block with different test data sets",
     "prefix": ["jest it each", "ite"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-it-only": {
     "body": ["it.only('${1:should }', () => {\n\t$0\n});"],
     "description": "creates an it block that runs only",
     "prefix": ["jest it only", "ito"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-it-skip": {
     "body": ["it.skip('${1:should }', () => {\n\t$0\n});"],
     "description": "creates an it block that will be skipped",
     "prefix": ["jest it skip", "its"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-it-todo": {
     "body": ["it.todo('${1:should }');"],
     "description": "creates a test placeholder",
     "prefix": ["jest it todo", "itt"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-it-async": {
     "body": ["it('${1:should }', async () => {\n\t$0\n});"],
     "description": "creates an it block with async callback function",
     "prefix": ["jest it async", "ita"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-jest-fn": {
     "body": ["jest.fn($0)"],
     "description": "creates jest.fn()",
     "prefix": ["jest fn", "jfn"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-template-cut": {
     "body": [
@@ -147,13 +147,13 @@
     ],
     "description": "creates a template to test a class under test",
     "prefix": ["jest template cut", "cut"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-test": {
     "body": ["test('${1:should }', () => {\n\t$0\n});"],
     "description": "creates a test block",
     "prefix": ["jest test", "test"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-test-each": {
     "body": [
@@ -166,210 +166,210 @@
     ],
     "description": "creates an test block with different test data sets",
     "prefix": ["jest test each", "teste"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-test-only": {
     "body": ["test.only('${1:should }', () => {\n\t$0\n});"],
     "description": "creates a test block  that runs only",
     "prefix": ["jest test only", "testo"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-test-skip": {
     "body": ["test.skip('${1:should }', () => {\n\t$0\n});"],
     "description": "creates a test block that will be skipped",
     "prefix": ["jest test skip", "tests"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-test-todo": {
     "body": ["test.todo('${1:should }');"],
     "description": "creates a test placeholder",
     "prefix": ["jest test todo", "testt"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-test-async": {
     "body": ["test('${1:should }', async () => {\n\t$0\n});"],
     "description": "creates an test block with async callback function",
     "prefix": ["jest test async", "testa"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tobe": {
     "body": ["expect($1).toBe($0);"],
     "description": "expects the first argument to be equal with the second one",
     "prefix": ["jest expect tobe", "tb"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tobecloseto": {
     "body": ["expect($1).toBeCloseTo(${2:number}, ${3:delta});$0"],
     "description": "expects the first argument to be close to the second one base on the delta",
     "prefix": ["jest expect tobecloseto", "tbct"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tobedefined": {
     "body": ["expect($1).toBeDefined();$0"],
     "description": "expects the argument is defined",
     "prefix": ["jest expect tobedefined", "tbd"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tobefalsy": {
     "body": ["expect($1).toBeFalsy();$0"],
     "description": "expects the argument is falsy",
     "prefix": ["jest expect tobefalsy", "tbf"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tobegreaterthan": {
     "body": ["expect($1).toBeGreaterThan($0);"],
     "description": "expects the argument is greater than or equal",
     "prefix": ["jest expect tobegreaterthan", "tbgt"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tobegreaterthanorequal": {
     "body": ["expect($1).toBeGreaterThanOrEqual($0);"],
     "description": "expects the argument is greater than",
     "prefix": ["jest expect tobegreaterthanorequal", "tbgte"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tobeinstanceof": {
     "body": ["expect($1).toBeInstanceOf($0);"],
     "description": "expects the argument is less than",
     "prefix": ["jest expect tobeinstanceof", "tbi"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tobelessthan": {
     "body": ["expect($1).toBeLessThan($0);"],
     "description": "expects the argument is less than",
     "prefix": ["jest expect tobelessthan", "tblt"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tobelessthanorequal": {
     "body": ["expect($1).toBeLessThanOrEqual($0);"],
     "description": "expects the argument is less than or equal",
     "prefix": ["jest expect tobelessthanorequal", "tblte"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tobenull": {
     "body": ["expect($1).toBeNull();$0"],
     "description": "expects the argument is null",
     "prefix": ["jest expect tobenull", "tbn"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tobetruthy": {
     "body": ["expect($1).toBeTruthy();$0"],
     "description": "expects the argument is truthy",
     "prefix": ["jest expect tobetruthy", "tbt"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tobeundefined": {
     "body": ["expect($1).toBeUndefined();$0"],
     "description": "expects the argument is undefined",
     "prefix": ["jest expect tobeundefined", "tbu"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tocontain": {
     "body": ["expect(${1:list}).toContain($0);"],
     "description": "expects the list contains the item (===)",
     "prefix": ["jest expect tocontain", "tc"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tocontainequal": {
     "body": ["expect(${1:list}).toContainEqual($0);"],
     "description": "expects the list contains the item (equals)",
     "prefix": ["jest expect tocontainequal", "tce"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-toequal": {
     "body": ["expect($1).toEqual($0);"],
     "description": "expects the first argument to be equal with the second one",
     "prefix": ["jest expect toequal", "te"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tohavebeencalled": {
     "body": ["expect($1).toHaveBeenCalled();$0"],
     "description": "returns true if the spy was called",
     "prefix": ["jest expect tohavebeencalled", "thbc"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tohavebeencalledtimes": {
     "body": ["expect($1).toHaveBeenCalledTimes($0);"],
     "description": "returns true if the spy has been called given times",
     "prefix": ["jest expect tohavebeencalledtimes", "thbct"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tohavebeencalledwith": {
     "body": ["expect($1).toHaveBeenCalledWith($0);"],
     "description": "returns true if the spy has been called with",
     "prefix": ["jest expect tohavebeencalledwith", "thbcw"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tohavebeenlastcalledwith": {
     "body": ["expect($1).toHaveBeenLastCalledWith($0);"],
     "description": "returns true if the spy has been last called with",
     "prefix": ["jest expect tohavebeenlastcalledwith", "thblcw"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tohavelength": {
     "body": ["expect($1).toHaveLength($0);"],
     "description": "expects the object to have length",
     "prefix": ["jest expect tohavelength", "thl"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tohaveproperty": {
     "body": ["expect($1).toHaveProperty(${2:keyPath}, ${3:value});$0"],
     "description": "returns true if the argument matches the second object",
     "prefix": ["jest expect tohaveproperty", "thp"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tomatch": {
     "body": ["expect($1).toMatch($0);"],
     "description": "returns true if the argument matches the second value",
     "prefix": ["jest expect tomatch", "tm"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tomatchinlinesnapshot": {
     "body": ["expect($1).toMatchInlineSnapshot($0);"],
     "description": "returns true if the argument matches the most recent inline snapshot",
     "prefix": ["jest expect tomatchinlinesnapshot", "tmis"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tomatchobject": {
     "body": ["expect($1).toMatchObject($0);"],
     "description": "returns true if the argument matches the second object",
     "prefix": ["jest expect tomatchobject", "tmo"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tomatchsnapshot": {
     "body": ["expect($1).toMatchSnapshot($0);"],
     "description": "returns true if the argument matches the most recent snapshot",
     "prefix": ["jest expect tomatchsnapshot", "tms"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tostrictequal": {
     "body": ["expect($1).toStrictEqual($0);"],
     "description": "expects the first argument to be strictly equal with the second one",
     "prefix": ["jest expect tostrictequal", "tse"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tothrow": {
     "body": ["expect(() => {\n\t$0\n}).toThrow($1);"],
     "description": "expects that the method will throw an error",
     "prefix": ["jest expect tothrow", "tt"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tothrowerror": {
     "body": ["expect(() => {\n\t$0\n}).toThrowError($1);"],
     "description": "expects that the method will throw an error",
     "prefix": ["jest expect tothrowerror", "tte"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tothrowerrormatchinginlinesnapshot": {
     "body": ["expect(() => {\n\t$0\n}).toThrowErrorMatchingInlineSnapshot();"],
     "description": "expects that the method will throw an error matching the inline snapshot",
     "prefix": ["jest expect tothrowerrormatchinginlinesnapshot", "ttemis"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   },
   "jest-tothrowerrormatchingsnapshot": {
     "body": ["expect(() => {\n\t$0\n}).toThrowErrorMatchingSnapshot();"],
     "description": "expects that the method will throw an error mathing the snapshpot",
     "prefix": ["jest expect tothrowerrormatchingsnapshot", "ttems"],
-    "scope": "javascript,typescript"
+    "scope": "javascript,javascriptreact,typescript,typescriptreact"
   }
 }


### PR DESCRIPTION
This PR addresses issue in #48 by adding extra scopes for supporting .jsx and .tsx files for jest snippets.