### PR TITLE
fix: refresh token only once after it expires

### DIFF
--- a/templates/frontend/src/components/shared/share-modal/share-modal.jsx
+++ b/templates/frontend/src/components/shared/share-modal/share-modal.jsx
@@ -211,7 +211,6 @@ const ShareModal = (props) => {
       }
 
       reset();
-      console.log('AFTER RESET', getValues('email'));
       // update list of users with whom the item is shared
       mutate(`getSharedTo-${id}`);
     } catch (error) {

--- a/templates/frontend/src/components/shared/template-form/template-form.jsx
+++ b/templates/frontend/src/components/shared/template-form/template-form.jsx
@@ -135,7 +135,6 @@ const TemplateForm = ({ initialValues, isCreatingNewTemplate = false, templateId
     if (Object.keys(errors).length > 0) {
       return;
     }
-    console.log('submitting');
 
     try {
       const newTemplateData = {
@@ -163,7 +162,7 @@ const TemplateForm = ({ initialValues, isCreatingNewTemplate = false, templateId
   const handleError = (error) => {
     showErrorModal(
       `Failed to ${isCreatingNewTemplate ? 'create template' : 'save changes'}${
-        error ? `: \n${error.message}.` : '.'
+        error ? `: \n${error.message}.` : ''
       }`
     );
   };

--- a/templates/frontend/src/hooks/use-token.js
+++ b/templates/frontend/src/hooks/use-token.js
@@ -19,11 +19,7 @@ const fetchToken = async () => {
 const useToken = () => {
   const { token, setToken } = useContext(AppContext);
 
-  const { data } = useSWR(() => (isExpired(token) ? 'token' : null), fetchToken, {
-    initialData: token,
-  });
-
-  return { token: data, setToken };
+  return { token, setToken };
 };
 
 export { useToken, isExpired, fetchToken };

--- a/templates/frontend/src/pages/api/auth/token.js
+++ b/templates/frontend/src/pages/api/auth/token.js
@@ -4,6 +4,7 @@ import { getSession } from 'next-auth/client';
 import jwt from 'utils/jwt';
 
 const MAX_AGE = process.env.JWT_API_MAX_AGE;
+const {SENTRY_ENABLED} = process.env;
 
 const refreshToken = async (req, res) => {
   const session = await getSession({ req });
@@ -15,4 +16,5 @@ const refreshToken = async (req, res) => {
   res.json({ token });
 };
 
-export default withSentry(refreshToken);
+const refresher = SENTRY_ENABLED === 'true' ? withSentry(refreshToken) : refreshToken;
+export default refresher;


### PR DESCRIPTION
This PR fixes issues with token refreshing:
* update token maximum once per request
* make it work both with and without sentry