### PR TITLE
fix: сhange graphql-engine image for working on Apple M1

### DIFF
--- a/templates/docker-compose.arm64.yml
+++ b/templates/docker-compose.arm64.yml
@@ -1,0 +1,3 @@
+services:
+  graphql-engine:
+    image: fedormelexin/graphql-engine-arm64:v2.0.1

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       POSTGRES_PASSWORD: postgrespassword
   graphql-engine:
-    image: fedormelexin/graphql-engine-arm64:v2.0.1
+    image: hasura/graphql-engine:v2.0.0-alpha.9
     ports:
       - '3010:8080'
     depends_on:

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       POSTGRES_PASSWORD: postgrespassword
   graphql-engine:
-    image: hasura/graphql-engine:v2.0.0-alpha.9
+    image: fedormelexin/graphql-engine-arm64:v2.0.1
     ports:
       - '3010:8080'
     depends_on:

--- a/templates/hasura/README.md
+++ b/templates/hasura/README.md
@@ -8,26 +8,31 @@
 ## Launch
 
 1. **Start containers**.
-   
+
    Run the following command from `templates` folder to create and start containers in `debug` mode:
    ```bash
    docker-compose up -d
    ```
+
+   For Mac computers with M1 Chip use command:
+   ```bash
+   docker-compose -f docker-compose.yml -f docker-compose.arm64.yml up -d
+   ```
 3. **Go to `templates/hasura` folder**.
 4. **Run `hasura` dashboard**.
-   
+
    If you want to use hasura and check the dashboard, install hasura-cli and run:
    ```bash
    hasura console
    ```
-5. **Create DB structure.** 
- 
+5. **Create DB structure.**
+
    In order to create db structure apply migrations and metadata using the following command from there:
 
    ```bash
    hasura migrate apply
    hasura metadata apply
    ```
-   
+
 ## Additional information
 Hasura connects to databases, REST servers, GraphQL servers, and third party APIs to provide a unified realtime GraphQL API across all data sources. Read more in Hasura [documentation](https://hasura.io/docs/latest/graphql/core/).


### PR DESCRIPTION
**Describe what changes this pull request brings**

This pull request fixes docker-compose for Apple M1 by replacing `hasura/graphql-engine` image to `fedormelexin/graphql-engine-arm64`

**Describe any additional changes**

N/A

**Steps to test**

N/A

**Screenshots**

N/A

**Checklist**

N/A

**TODO**

- [ ] Сheck these changes on a computer without M1 chip

**References**

N/A
