### PR TITLE
feat: add clone button to context menu in the sidebar templates navigation

### DIFF
--- a/templates/frontend/src/components/shared/sidebar/authorised-sidebar/templates-groups-tree/template-group-item/template-group-item.jsx
+++ b/templates/frontend/src/components/shared/sidebar/authorised-sidebar/templates-groups-tree/template-group-item/template-group-item.jsx
@@ -103,6 +103,8 @@ const TemplateGroupItem = ({
                 key={template.id}
                 name={template.name}
                 templateId={template.id}
+                prompts={template.prompts}
+                files={template.files}
                 favourite={template.favourite || false}
                 shared={shared}
               />
@@ -164,6 +166,8 @@ TemplateGroupItem.propTypes = {
     PropTypes.shape({
       name: PropTypes.string.isRequired,
       id: PropTypes.string.isRequired,
+      prompts: PropTypes.string.isRequired,
+      files: PropTypes.string.isRequired,
       favourite: PropTypes.bool,
       shared: PropTypes.bool,
     })

--- a/templates/frontend/src/components/shared/sidebar/authorised-sidebar/templates-groups-tree/templates-groups-tree.jsx
+++ b/templates/frontend/src/components/shared/sidebar/authorised-sidebar/templates-groups-tree/templates-groups-tree.jsx
@@ -37,6 +37,8 @@ const TemplatesGroupsTree = () => {
               key={template.id}
               name={template.name}
               templateId={template.id}
+              prompts={template.prompts}
+              files={template.files}
               favourite={template.favourite || false}
             />
           ))}
@@ -62,6 +64,8 @@ const TemplatesGroupsTree = () => {
               key={template.id}
               name={template.name}
               templateId={template.id}
+              prompts={template.prompts}
+              files={template.files}
               favourite={template.favourite || false}
               shared
             />


### PR DESCRIPTION
**Describe what changes this pull request brings**
This pull request adds `Clone` button to context menu in the sidebar templates navigation

**Describe any additional changes**
N/A

**Steps to test**
1. Open main page
2. Choose one template and click on `Clone` in context menu in the sidebar navigation
3. Confirm that the template was cloned

**Screenshots**
<img width="1440" alt="Снимок экрана 2021-07-28 в 23 49 04" src="https://user-images.githubusercontent.com/18118729/127394296-e49c38a3-a011-4235-8bf0-0630a752132c.png">

**Checklist**
- [x] I've checked for typos
- [x] I've made sure overall structure consistency is preserved
- [x] I've made sure overall headings hierarchy is preserved
- [x] I've reread proposed changes twice

**TODO**
N/A

**References**
[Issue #85 ](https://github.com/snipsnapdev/snipsnap/issues/85)
