### PR TITLE
feat: allow to use square brackets in file and folder names

### DIFF
--- a/templates/frontend/src/components/shared/file-browser/add-file-modal/add-file-modal.jsx
+++ b/templates/frontend/src/components/shared/file-browser/add-file-modal/add-file-modal.jsx
@@ -17,7 +17,7 @@ const schema = yup.object().shape({
     .string()
     .required('Name is required')
     .matches(/^[A-Za-z0-9.{}\-_\s\[\]]+$/, {
-      message: 'Name is not valid',
+      message: 'Name should have only allowed symbols A-Za-z0-9.{}[]-_',
     }),
 });
 const cx = classNames.bind(styles);

--- a/templates/frontend/src/components/shared/file-browser/add-file-modal/add-file-modal.jsx
+++ b/templates/frontend/src/components/shared/file-browser/add-file-modal/add-file-modal.jsx
@@ -16,7 +16,7 @@ const schema = yup.object().shape({
   name: yup
     .string()
     .required('Name is required')
-    .matches(/^[A-Za-z0-9.{}\-_\s]+$/, {
+    .matches(/^[A-Za-z0-9.{}\-_\s\[\]]+$/, {
       message: 'Name is not valid',
     }),
 });

--- a/templates/frontend/src/components/shared/file-browser/add-folder-modal/add-folder-modal.jsx
+++ b/templates/frontend/src/components/shared/file-browser/add-folder-modal/add-folder-modal.jsx
@@ -16,8 +16,8 @@ const schema = yup.object().shape({
   name: yup
     .string()
     .required('Name is required')
-    .matches(/^[A-Za-z0-9.{}\-_\s]+$/, {
-      message: 'Name should have only allowed symbols A-Za-z0-9.{}-_ ',
+    .matches(/^[A-Za-z0-9.{}\-_\s\[\]]+$/, {
+      message: 'Name should have only allowed symbols A-Za-z0-9.{}[]-_',
     }),
 });
 const cx = classNames.bind(styles);


### PR DESCRIPTION
Next.js templates can contain square brackets in folder or file name. It's needed for [Dynamic routes](https://nextjs.org/docs/routing/dynamic-routes) in the Next.js 12 and below and for [Dynamic segments](https://beta.nextjs.org/docs/routing/defining-routes#dynamic-segments) in the Next.js 13 and above.